### PR TITLE
auto_merge / auto_patch_merge の if 条件を修正

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -3,7 +3,7 @@ on: pull_request
 permissions: {}
 jobs:
   merge:
-    if: ${{ github.event_name == 'dependabot[bot]'}}  # DependabotのPRのみ
+    if: ${{ github.actor == 'dependabot[bot]' }}      # DependabotのPRのみ
     runs-on: ubuntu-latest
     permissions:                                      # マージに必要なパーミッション
       contents: write

--- a/.github/workflows/auto_patch_merge.yml
+++ b/.github/workflows/auto_patch_merge.yml
@@ -3,7 +3,7 @@ on: pull_request
 permissions: {}
 jobs:
   merge:
-    if: ${{ github.event_name == 'dependabot[bot]'}}  # DependabotのPRのみ
+    if: ${{ github.actor == 'dependabot[bot]' }}      # DependabotのPRのみ
     runs-on: ubuntu-latest
     permissions:                                      # マージに必要なパーミッション
       contents: write


### PR DESCRIPTION
## 概要

auto_merge.yml / auto_patch_merge.yml の `if` 条件が `github.event_name`（イベント名 = `pull_request`）をアクター名 `dependabot[bot]` と比較しており、常に false でジョブが一度も実行されないバグを修正します。

Fixes #327

## 変更内容

```diff
-    if: ${{ github.event_name == 'dependabot[bot]'}}  # DependabotのPRのみ
+    if: ${{ github.actor == 'dependabot[bot]' }}      # DependabotのPRのみ
```

- 対象: `.github/workflows/auto_merge.yml` / `.github/workflows/auto_patch_merge.yml`（各1行）
- GitHub 公式の Dependabot 自動マージ例と同じ `github.actor` 判定に変更
- リポジトリ内の既存パターン（`conditions_workflow.yml` の actor 判定）とも整合

## 検証

- actionlint: PASS
- conftest（policy/workflow.rego）: 4 tests / 4 passed
- `go test ./...`（go/excellent）: ok

## 留意点（スコープ外）

- Dependabot トリガーの PR では `GITHUB_TOKEN` が read-only になる場合があり、`gh pr merge` が権限不足で失敗する可能性は残ります。次回 Dependabot PR 発生時に実機確認を推奨。
- Dependabot ブランチへ人間が追いコミットした場合は actor 判定によりスキップされます（デモ用途のため許容）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
